### PR TITLE
Old URL deprecate warning message

### DIFF
--- a/api/redirect.js
+++ b/api/redirect.js
@@ -1,6 +1,5 @@
 const sdk = require("node-appwrite");
 
-// Initialize Appwrite client
 const client = new sdk.Client()
   .setEndpoint(process.env.APPWRITE_ENDPOINT)
   .setProject(process.env.APPWRITE_PROJECT);
@@ -9,24 +8,47 @@ const database = new sdk.Databases(client);
 
 export default async function handler(req, res) {
   const { shortCode } = req.query;
-
-  console.log("shortCode", shortCode);
+  const host = req.headers.host;
 
   if (!shortCode) {
-    return res.status(400).json({ error: "shortCode is required" });
+    return res.status(400).send("shortCode is required");
   }
 
   try {
-    // Retrieve the document by shortCode
     const result = await database.getDocument(
       process.env.URL_DB,
       process.env.URL_COL,
       shortCode
     );
-
     const longURL = result.longURL;
 
-    // Redirect to the original URL
+    if (host && host.endsWith("example.old")) {
+      res.setHeader("Content-Type", "text/html");
+      return res.send(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="UTF-8">
+            <title>Deprecated Domain</title>
+            <meta http-equiv="refresh" content="5;url=${longURL}">
+            <style>
+              body { font-family: sans-serif; padding: 2rem; text-align: center; background: #fffbe6; }
+              .box { border: 1px solid #ffe58f; background: #fffbe6; padding: 2rem; border-radius: 8px; display: inline-block; }
+              a { color: #fa8c16; text-decoration: underline; }
+            </style>
+          </head>
+          <body>
+            <div class="box">
+              <h2>⚠️ You're visiting from a deprecated domain</h2>
+              <p><strong>example.old</strong> will be shut down on <strong>30 November</strong>.</p>
+              <p>Please update your bookmarks to the new domain: <a href="https://example.com">example.com</a></p>
+              <p>Redirecting to: <a href="${longURL}">${longURL}</a> in 5 seconds...</p>
+            </div>
+          </body>
+        </html>
+      `);
+    }
+
     return res.redirect(302, longURL);
   } catch (error) {
     return res.status(404).json({ error: error.message });


### PR DESCRIPTION
This pull request updates the `api/redirect.js` file to improve domain handling and enhance user experience for deprecated domains. The most important changes include adding a custom HTML response for users visiting from a deprecated domain and refining error handling and logging.

Enhancements for deprecated domain handling:

* Added a check for requests coming from the `example.old` domain and implemented a custom HTML response informing users about the deprecation and redirecting them to the new domain (`example.com`). The response includes styling and a countdown for redirection.

Error handling improvements:

* Updated the error response for missing `shortCode` to use `res.send` instead of `res.json`, simplifying the response format.

Code cleanup:

* Removed unnecessary comments, such as those describing the initialization of the Appwrite client and the document retrieval process. [[1]](diffhunk://#diff-be36094c16cf78b67d83bedcc832e59fc9bdeb8c21875010c1066f4fa0137602L3) [[2]](diffhunk://#diff-be36094c16cf78b67d83bedcc832e59fc9bdeb8c21875010c1066f4fa0137602L12-R51)
* Removed a `console.log` statement for `shortCode`, reducing unnecessary logging.